### PR TITLE
Fix next layer input dim cal

### DIFF
--- a/neuralpy/activation_functions/gelu.py
+++ b/neuralpy/activation_functions/gelu.py
@@ -27,7 +27,7 @@ class GELU:
 
         self.__name = name
 
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
             Here for this activation function, we dont need it
@@ -46,5 +46,4 @@ class GELU:
             No need to call this method for using NeuralPy.
         """
         # Returning all the details of the activation function
-        return get_activation_details(
-                None, None, self.__name, "GELU", _GELU, None)
+        return get_activation_details(self.__name, "GELU", _GELU, None)

--- a/neuralpy/activation_functions/leaky_relu.py
+++ b/neuralpy/activation_functions/leaky_relu.py
@@ -37,7 +37,7 @@ class LeakyReLU:
         self.__name = name
 
     # pylint: disable=no-self-use,unused-argument
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
             Here for this activation function, we dont need it
@@ -56,7 +56,7 @@ class LeakyReLU:
             No need to call this method for using NeuralPy.
         """
         # Returning all the details of the activation function
-        return get_activation_details(None, None, self.__name, 'LeakyReLU', _LeakyReLU, {
+        return get_activation_details(self.__name, 'LeakyReLU', _LeakyReLU, {
             'negative_slope': self.__negative_slope,
             'inplace': False
         })

--- a/neuralpy/activation_functions/relu.py
+++ b/neuralpy/activation_functions/relu.py
@@ -14,6 +14,7 @@ class ReLU:
             name=None: (String) Name of the activation function layer,
                 if not provided then automatically calculates a unique name for the layer
     """
+
     def __init__(self, name=None):
         """
             __init__ method for the ReLU Activation Function class
@@ -29,7 +30,7 @@ class ReLU:
         self.__name = name
 
     # pylint: disable=no-self-use,unused-argument
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
             Here for this activation function, we dont need it
@@ -48,6 +49,6 @@ class ReLU:
             No need to call this method for using NeuralPy.
         """
         # Returning all the details of the activation function
-        return get_activation_details(None, None, self.__name, 'ReLU', _ReLU, {
+        return get_activation_details(self.__name, 'ReLU', _ReLU, {
             'inplace': False
         })

--- a/neuralpy/activation_functions/selu.py
+++ b/neuralpy/activation_functions/selu.py
@@ -14,6 +14,7 @@ class SELU:
                 name=None: (String) Name of the activation function layer,
                     if not provided then automatically calculates a unique name for the layer
     """
+
     def __init__(self, name=None):
         """
             __init__ method for the SELU Activation Function class
@@ -28,7 +29,7 @@ class SELU:
 
         self.__name = name
 
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
             Here for this activation function, we dont need it
@@ -47,7 +48,6 @@ class SELU:
             No need to call this method for using NeuralPy.
         """
         # Returning all the details of the activation function
-        return get_activation_details(
-                None, None, self.__name, 'SELU', _SELU, {
-                    'inplace': False
-                    })
+        return get_activation_details(self.__name, 'SELU', _SELU, {
+            'inplace': False
+        })

--- a/neuralpy/activation_functions/sigmoid.py
+++ b/neuralpy/activation_functions/sigmoid.py
@@ -3,6 +3,7 @@
 from torch.nn import Sigmoid as _Sigmoid
 from .utils import get_activation_details, validate_name_field
 
+
 class Sigmoid:
     """
         Applies a element-wise Sigmoid or Logistic function to the input tensor.
@@ -11,6 +12,7 @@ class Sigmoid:
             name=None: (String) Name of the activation function layer,
                 if not provided then automatically calculates a unique name for the layer.
     """
+
     def __init__(self, name=None):
         """
             __init__ method for the Sigmoid Activation Function class
@@ -27,7 +29,7 @@ class Sigmoid:
         self.__name = name
 
     # pylint: disable=no-self-use,unused-argument
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
             Here for this activation function, we dont need it
@@ -46,4 +48,4 @@ class Sigmoid:
             No need to call this method for using NeuralPy.
         """
         # Returning all the details of the activation function
-        return get_activation_details(None, None, self.__name, 'Sigmoid', _Sigmoid, None)
+        return get_activation_details(self.__name, 'Sigmoid', _Sigmoid, None)

--- a/neuralpy/activation_functions/softmax.py
+++ b/neuralpy/activation_functions/softmax.py
@@ -3,6 +3,7 @@
 from torch.nn import Softmax as _Softmax
 from .utils import get_activation_details, validate_name_field
 
+
 class Softmax:
     """
         Applies the Softmax function to the input Tensor rescaling input to the range [0,1].
@@ -13,6 +14,7 @@ class Softmax:
             name=None: (String) Name of the activation function layer,
                 if not provided then automatically calculates a unique name for the layer.
     """
+
     def __init__(self, dim=None, name=None):
         """
             __init__ method for the Sigmoid Activation Function class
@@ -31,7 +33,7 @@ class Softmax:
         self.__name = name
 
     # pylint: disable=no-self-use,unused-argument
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
             Here for this activation function, we dont need it
@@ -50,6 +52,6 @@ class Softmax:
             No need to call this method for using NeuralPy.
         """
         # Returning all the details of the activation function
-        return get_activation_details(None, None, self.__name, 'Softmax', _Softmax, {
+        return get_activation_details(self.__name, 'Softmax', _Softmax, {
             'dim': self.__dim
         })

--- a/neuralpy/activation_functions/tanh.py
+++ b/neuralpy/activation_functions/tanh.py
@@ -12,6 +12,7 @@ class Tanh:
             name=None: (String) Name of the activation function layer,
                 if not provided then automatically calculates a unique name for the layer
     """
+
     def __init__(self, name=None):
         """
             __init__ method for the Tanh Activation Function class
@@ -27,7 +28,7 @@ class Tanh:
         self.__name = name
 
     # pylint: disable=no-self-use,unused-argument
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
             Here for this activation function, we dont need it
@@ -46,4 +47,4 @@ class Tanh:
             No need to call this method for using NeuralPy.
         """
         # Returning all the details of the activation function
-        return get_activation_details(None, None, self.__name, 'Tanh', _Tanh, None)
+        return get_activation_details(self.__name, 'Tanh', _Tanh, None)

--- a/neuralpy/activation_functions/utils.py
+++ b/neuralpy/activation_functions/utils.py
@@ -1,13 +1,12 @@
 """Utility functions for activation function"""
 
 # pylint: disable=too-many-arguments
-def get_activation_details(n_inputs, n_nodes, name, layer_type, layer, keyword_arguments):
+def get_activation_details(name, layer_type, layer, keyword_arguments):
     """
     	Creates the layer details data for the activation function
     """
     return {
-        'n_inputs': n_inputs,
-        'n_nodes': n_nodes,
+        'layer_details': None,
         'name': name,
         'type': layer_type,
         'layer': layer,

--- a/neuralpy/layers/bilinear.py
+++ b/neuralpy/layers/bilinear.py
@@ -87,6 +87,8 @@ class Bilinear:
 
             if layer_type == "dense":
                 self.__n_inputs = prev_input_dim[0]
+            elif layer_type == "bilinear":
+                self.__n_inputs = prev_input_dim[0]
             else:
                 raise ValueError("Unsupported previous layer, please provide your own input shape for the layer")
 
@@ -99,7 +101,7 @@ class Bilinear:
         """
         # Returning all the details of the layer
         return {
-            'layer_details': (self.__n_inputs,),
+            'layer_details': (self.__n_nodes,),
             'name': self.__name,
             'type': 'Bilinear',
             'layer': _BiLinear,

--- a/neuralpy/layers/bilinear.py
+++ b/neuralpy/layers/bilinear.py
@@ -74,7 +74,7 @@ class Bilinear:
         self.__bias = bias
         self.__name = name
 
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, prev_layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
 
@@ -83,7 +83,12 @@ class Bilinear:
         """
         # Checking if n_inputs is there or not, not overwriting the n_input field
         if not self.__n_inputs:
-            self.__n_inputs = prev_input_dim
+            layer_type = prev_layer_type.lower()
+
+            if layer_type == "dense":
+                self.__n_inputs = prev_input_dim[0]
+            else:
+                raise ValueError("Unsupported previous layer, please provide your own input shape for the layer")
 
     def get_layer(self):
         """
@@ -94,9 +99,7 @@ class Bilinear:
         """
         # Returning all the details of the layer
         return {
-            'n_inputs': self.__n_inputs,
-            'n_inputs2': self.__n_inputs2,
-            'n_nodes': self.__n_nodes,
+            'layer_details': (self.__n_inputs,),
             'name': self.__name,
             'type': 'Bilinear',
             'layer': _BiLinear,

--- a/neuralpy/layers/dense.py
+++ b/neuralpy/layers/dense.py
@@ -66,7 +66,9 @@ class Dense:
         # Checking if n_inputs is there or not, not overwriting the n_input field
         if not self.__n_inputs:
             layer_type = prev_layer_type.lower()
-
+            
+            # based on the prev layer type, predicting the n_inputs
+            # to support more layers, we need to add some more statements
             if layer_type == "dense":
                 self.__n_inputs = prev_input_dim[0]
             else:

--- a/neuralpy/layers/dense.py
+++ b/neuralpy/layers/dense.py
@@ -81,8 +81,7 @@ class Dense:
         """
         # Returning all the details of the layer
         return {
-            'n_inputs': self.__n_inputs,
-            'n_nodes': self.__n_nodes,
+            'layer_details': (self.__n_nodes,),
             'name': self.__name,
             'type': 'Dense',
             'layer': Linear,

--- a/neuralpy/layers/dense.py
+++ b/neuralpy/layers/dense.py
@@ -56,7 +56,7 @@ class Dense:
         self.__bias = bias
         self.__name = name
 
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, prev_layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
 
@@ -65,7 +65,12 @@ class Dense:
         """
         # Checking if n_inputs is there or not, not overwriting the n_input field
         if not self.__n_inputs:
-            self.__n_inputs = prev_input_dim
+            layer_type = prev_layer_type.lower()
+
+            if layer_type == "dense":
+                self.__n_inputs = prev_input_dim[0]
+            else:
+                raise ValueError("Unsupported previous layer, please provide your own input shape for the layer")
 
     def get_layer(self):
         """

--- a/neuralpy/models/model_helper.py
+++ b/neuralpy/models/model_helper.py
@@ -148,16 +148,17 @@ def build_layer_from_dict(layer_refs):
 
     # Strong the output dimension, for the next layer,
     # we need this to calculate the next input layer dim
-    prev_output_dim = None
+    prev_layer_details = None
+    prev_layer_type = None
 
     # Iterating through the layers
     for index, layer_ref in enumerate(layer_refs):
 
         # Generating n_input if not present
-        if isinstance(prev_output_dim, int):
+        if prev_layer_details and prev_layer_type:
             # For each layer, we have this method that returns the new input layer for next dim
             # based on the previous output dim
-            layer_ref.get_input_dim(prev_output_dim)
+            layer_ref.get_input_dim(prev_layer_details)
 
         # Getting the details of the layer using the get_layer method
         layer_details = layer_ref.get_layer()
@@ -165,7 +166,7 @@ def build_layer_from_dict(layer_refs):
         # Storing the layer details
         layer_name = layer_details["name"]
         layer_type = layer_details["type"]
-        layer_nodes = layer_details["n_nodes"]
+        layer_details_info = layer_details["layer_details"]
         layer_arguments = layer_details["keyword_arguments"]
 
         # Here we are just storing the ref, not the initialized layer
@@ -187,10 +188,8 @@ def build_layer_from_dict(layer_refs):
         # Appending the layer to layers array
         layers.append((layer_name, layer))
 
-        # Checking layer_nodes value against some condition,
-        # and then storing the n_nodes to calculate the input dim of next layer
-        if layer_nodes is not None:
-            prev_output_dim = layer_nodes
+        prev_layer_details = layer_details_info
+        prev_layer_type = layer_type
 
     return layers
 

--- a/neuralpy/models/model_helper.py
+++ b/neuralpy/models/model_helper.py
@@ -157,7 +157,14 @@ def build_layer_from_dict(layer_refs):
         # Generating n_input if not present
         if prev_layer_details and prev_layer_type:
             # For each layer, we have this method that returns the new input layer for next dim
-            # based on the previous output dim
+            # based on the previous layer details and type
+            # the prev_layer_details is a tuple that contains all the information
+            # need for the layer to predict the input shape
+            # The prev_layer_type is the type of the layer, based on it, 
+            # the layers can calculate the input shape
+            # for example, in cnn, after the conv layers, when the dense layer need to do 
+            # some complicated calculations to get the input shape of the Dense layer 
+            # based on the input shape, stride, padding, etc
             layer_ref.get_input_dim(prev_layer_details, prev_layer_type)
 
         # Getting the details of the layer using the get_layer method

--- a/neuralpy/models/model_helper.py
+++ b/neuralpy/models/model_helper.py
@@ -26,7 +26,7 @@ def is_valid_layer(layer):
             return False
 
         # Here im checking all the keys of object returned from the get_layer method
-        layer_details = layer_details["layer_details"]
+        layer_details_info = layer_details["layer_details"]
 
         layer_name = layer_details["name"]
         layer_type = layer_details["type"]
@@ -35,7 +35,7 @@ def is_valid_layer(layer):
         layer_function_ref = layer_details["layer"]
 
         # The layer_details should be tuple with all the information for the next layer
-        if layer_details and not isinstance(layer_details, tuple):
+        if layer_details_info and not isinstance(layer_details_info, tuple):
             return False
 
         # Validating layer_name

--- a/neuralpy/models/model_helper.py
+++ b/neuralpy/models/model_helper.py
@@ -187,9 +187,10 @@ def build_layer_from_dict(layer_refs):
 
         # Appending the layer to layers array
         layers.append((layer_name, layer))
-
-        prev_layer_details = layer_details_info
-        prev_layer_type = layer_type
+        
+        if layer_details_info: 
+            prev_layer_details = layer_details_info
+            prev_layer_type = layer_type
 
     return layers
 

--- a/neuralpy/models/model_helper.py
+++ b/neuralpy/models/model_helper.py
@@ -26,8 +26,7 @@ def is_valid_layer(layer):
             return False
 
         # Here im checking all the keys of object returned from the get_layer method
-        layer_inputs = layer_details["n_inputs"]
-        layer_nodes = layer_details["n_nodes"]
+        layer_details = layer_details["layer_details"]
 
         layer_name = layer_details["name"]
         layer_type = layer_details["type"]
@@ -35,17 +34,8 @@ def is_valid_layer(layer):
         layer_arguments = layer_details["keyword_arguments"]
         layer_function_ref = layer_details["layer"]
 
-        # Validating layer_inputs
-        if "n_inputs2" in layer_details.keys():
-            layer_inputs2 = layer_details["n_inputs2"]
-            if layer_inputs2 and not isinstance(
-                    layer_inputs2, int) and layer_inputs2 < 1:
-                return False
-        if layer_inputs and not isinstance(layer_inputs, int) and layer_inputs < 1:
-            return False
-
-        # Validating layer_nodes
-        if layer_nodes and not isinstance(layer_nodes, int) and layer_nodes < 1:
+        # The layer_details should be tuple with all the information for the next layer
+        if layer_details and not isinstance(layer_details, tuple):
             return False
 
         # Validating layer_name

--- a/neuralpy/models/model_helper.py
+++ b/neuralpy/models/model_helper.py
@@ -158,7 +158,7 @@ def build_layer_from_dict(layer_refs):
         if prev_layer_details and prev_layer_type:
             # For each layer, we have this method that returns the new input layer for next dim
             # based on the previous output dim
-            layer_ref.get_input_dim(prev_layer_details)
+            layer_ref.get_input_dim(prev_layer_details, prev_layer_type)
 
         # Getting the details of the layer using the get_layer method
         layer_details = layer_ref.get_layer()

--- a/neuralpy/regulariziers/dropout.py
+++ b/neuralpy/regulariziers/dropout.py
@@ -39,7 +39,7 @@ class Dropout:
         self.__name = name
 
     # pylint: disable=no-self-use,unused-argument
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
 
@@ -58,8 +58,7 @@ class Dropout:
         """
         # Returning all the details of the layer
         return {
-            'n_inputs': None,
-            'n_nodes': None,
+            'layer_details': None,
             'name': self.__name,
             'type': 'Dropout',
             'layer': _Dropout,

--- a/neuralpy/regulariziers/dropout2d.py
+++ b/neuralpy/regulariziers/dropout2d.py
@@ -39,7 +39,7 @@ class Dropout2D:
         self.__name = name
 
     # pylint: disable=no-self-use,unused-argument
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
 
@@ -58,8 +58,7 @@ class Dropout2D:
         """
         # Returning all the details of the layer
         return {
-            'n_inputs': None,
-            'n_nodes': None,
+            'layer_details': None,
             'name': self.__name,
             'type': 'Dropout2D',
             'layer': _Dropout2D,

--- a/neuralpy/regulariziers/dropout3d.py
+++ b/neuralpy/regulariziers/dropout3d.py
@@ -39,7 +39,7 @@ class Dropout3D:
         self.__name = name
 
     # pylint: disable=no-self-use,unused-argument
-    def get_input_dim(self, prev_input_dim):
+    def get_input_dim(self, prev_input_dim, layer_type):
         """
             This method calculates the input shape for layer based on previous output layer.
 
@@ -58,8 +58,7 @@ class Dropout3D:
         """
         # Returning all the details of the layer
         return {
-            'n_inputs': None,
-            'n_nodes': None,
+            'layer_details': None,
             'name': self.__name,
             'type': 'Dropout3D',
             'layer': _Dropout3D,

--- a/tests/neuralpy/activation_functions/test_gelu.py
+++ b/tests/neuralpy/activation_functions/test_gelu.py
@@ -25,15 +25,13 @@ names = ["test1", "test2"]
 def test_gelu_get_input_dim_and_get_layer_method(name):
     x = GELU(name=name)
 
-    assert x.get_input_dim(12) == None
+    assert x.get_input_dim(12, "dense") == None
 
     details = x.get_layer()
 
     assert isinstance(details, dict) == True
 
-    assert details["n_inputs"] == None
-
-    assert details["n_nodes"] == None
+    assert details["layer_details"] == None
 
     assert details["name"] == name
 

--- a/tests/neuralpy/activation_functions/test_leaky_relu.py
+++ b/tests/neuralpy/activation_functions/test_leaky_relu.py
@@ -27,15 +27,13 @@ names = ["test1", "test2"]
 def test_leaky_relu_get_input_dim_and_get_layer_method(negative_slope, name):
     x = LeakyReLU(negative_slope=negative_slope, name=name)
 
-    assert x.get_input_dim(12) == None
+    assert x.get_input_dim(12, "dense") == None
 
     details = x.get_layer()
 
     assert isinstance(details, dict) == True
 
-    assert details["n_inputs"] == None
-
-    assert details["n_nodes"] == None
+    assert details["layer_details"] == None
 
     assert details["name"] == name
 

--- a/tests/neuralpy/activation_functions/test_relu.py
+++ b/tests/neuralpy/activation_functions/test_relu.py
@@ -23,15 +23,13 @@ names = ["test1", "test2"]
 def test_relu_get_input_dim_and_get_layer_method(name):
     x = ReLU(name=name)
 
-    assert x.get_input_dim(12) == None
+    assert x.get_input_dim(12, "dense") == None
 
     details = x.get_layer()
 
     assert isinstance(details, dict) == True
 
-    assert details["n_inputs"] == None
-
-    assert details["n_nodes"] == None
+    assert details["layer_details"] == None
 
     assert details["name"] == name
 

--- a/tests/neuralpy/activation_functions/test_selu.py
+++ b/tests/neuralpy/activation_functions/test_selu.py
@@ -25,15 +25,13 @@ names = ["test1", "test2"]
 def test_selu_get_input_dim_and_get_layer_method(name):
     x = SELU(name=name)
 
-    assert x.get_input_dim(23) == None
+    assert x.get_input_dim(23, "dense") == None
 
     details = x.get_layer()
 
     assert isinstance(details, dict) == True
 
-    assert details["n_inputs"] == None
-
-    assert details["n_nodes"] == None
+    assert details["layer_details"] == None
 
     assert details["name"] == name
 

--- a/tests/neuralpy/activation_functions/test_sigmoid.py
+++ b/tests/neuralpy/activation_functions/test_sigmoid.py
@@ -23,15 +23,13 @@ names = ["test1", "test2"]
 def test_get_input_dim_and_get_layer_method(name):
     x = Sigmoid(name=name)
 
-    assert x.get_input_dim(12) == None
+    assert x.get_input_dim(12, "dense") == None
 
     details = x.get_layer()
 
     assert isinstance(details, dict) == True
 
-    assert details["n_inputs"] == None
-
-    assert details["n_nodes"] == None
+    assert details["layer_details"] == None
 
     assert details["name"] == name
 

--- a/tests/neuralpy/activation_functions/test_softmax.py
+++ b/tests/neuralpy/activation_functions/test_softmax.py
@@ -27,15 +27,13 @@ names = ["test1", "test2"]
 def test_leaky_relu_get_input_dim_and_get_layer_method(dim, name):
     x = Softmax(dim=dim, name=name)
 
-    assert x.get_input_dim(12) == None
+    assert x.get_input_dim(12, "dense") == None
 
     details = x.get_layer()
 
     assert isinstance(details, dict) == True
 
-    assert details["n_inputs"] == None
-
-    assert details["n_nodes"] == None
+    assert details["layer_details"] == None
 
     assert details["name"] == name
 

--- a/tests/neuralpy/activation_functions/test_tanh.py
+++ b/tests/neuralpy/activation_functions/test_tanh.py
@@ -23,15 +23,13 @@ names = ["test1", "test2"]
 def test_tanh_get_input_dim_and_get_layer_method(name):
     x = Tanh(name=name)
 
-    assert x.get_input_dim(12) == None
+    assert x.get_input_dim(12, "dense") == None
 
     details = x.get_layer()
 
     assert isinstance(details, dict) == True
 
-    assert details["n_inputs"] == None
-
-    assert details["n_nodes"] == None
+    assert details["layer_details"] == None
 
     assert details["name"] == name
 

--- a/tests/neuralpy/layers/test_bilinear.py
+++ b/tests/neuralpy/layers/test_bilinear.py
@@ -2,39 +2,43 @@ import pytest
 from torch.nn import Bilinear as BiLinear
 from neuralpy.layers import Bilinear
 
+
 def test_bilinear_should_throw_type_error():
     with pytest.raises(TypeError) as ex:
         x = Bilinear()
 
+
 @pytest.mark.parametrize(
-	"n_nodes, n_inputs, n_inputs2, bias, name", 
-	[
-		(0.3, 0.3, 0.3, 0.36, False),
-		(False, 0.3, 0.3, 0.36, False),
-		(4, 0.3, 0.36, 0.3, False),
-		(10, False, 0.36, 0.3, False),
-		(10, "invalid", 0.36, 0.3, False),
-		(10, 10, 0.36, 0.3, False),
-		(10, 10, "invalid", 0.3, False),
+    "n_nodes, n_inputs, n_inputs2, bias, name",
+    [
+        (0.3, 0.3, 0.3, 0.36, False),
+        (False, 0.3, 0.3, 0.36, False),
+        (4, 0.3, 0.36, 0.3, False),
+        (10, False, 0.36, 0.3, False),
+        (10, "invalid", 0.36, 0.3, False),
+        (10, 10, 0.36, 0.3, False),
+        (10, 10, "invalid", 0.3, False),
         (10, 10, 10, "invalid", False),
         (10, 10, 10, 4, False),
-		(10, 10, 10, True, False),
-		(10, 10, 10, True, 19),
-		(10, 10, 10, True, ""),
-	]
+        (10, 10, 10, True, False),
+        (10, 10, 10, True, 19),
+        (10, 10, 10, True, ""),
+    ]
 )
 def test_bilinear_should_throw_value_error(
         n_nodes, n_inputs, n_inputs2, bias, name):
     with pytest.raises(ValueError) as ex:
         x = Bilinear(
-                n_nodes=n_nodes, n1_features=n_inputs,
-                n2_features=n_inputs2, bias=bias, name=name)
+            n_nodes=n_nodes, n1_features=n_inputs,
+            n2_features=n_inputs2, bias=bias, name=name)
+
 
 n_nodes = [6, 3]
 n_inputs = [6, 5, None]
 n_inputs2 = [6, 5, None]
 biases = [True, False]
 names = ["Test", None]
+
 
 @pytest.mark.parametrize(
     "n_nodes, n_inputs, n_inputs2, bias, name",
@@ -49,24 +53,19 @@ def test_bilinear_get_layer_method(
         n_nodes, n_inputs, n_inputs2, bias, name):
 
     x = Bilinear(
-            n_nodes=n_nodes, n1_features=n_inputs,
-            n2_features=n_inputs2, bias=bias, name=name)
+        n_nodes=n_nodes, n1_features=n_inputs,
+        n2_features=n_inputs2, bias=bias, name=name)
 
-    prev_dim = 6
+    prev_dim = (6,)
 
     if n_inputs is None:
-        x.get_input_dim(prev_dim)
+        x.get_input_dim(prev_dim, "dense")
 
     details = x.get_layer()
 
     assert isinstance(details, dict) == True
 
-    if n_inputs:
-        assert details['n_inputs'] == n_inputs
-    else:
-        assert details['n_inputs'] == prev_dim
-
-    assert details["n_nodes"] == n_nodes
+    assert details["layer_details"] == (n_nodes,)
 
     assert details["name"] == name
 
@@ -76,11 +75,10 @@ def test_bilinear_get_layer_method(
 
     if n_inputs:
         assert details["keyword_arguments"]["in_features1"] == n_inputs
-        assert details["keyword_arguments"]["in_features2"] == n_inputs2
-
     else:
-        assert details["keyword_arguments"]["in_features1"] == prev_dim
-        assert details["keyword_arguments"]["in_features2"] == n_inputs2
+        assert details["keyword_arguments"]["in_features1"] == prev_dim[0]
+    
+    assert details["keyword_arguments"]["in_features2"] == n_inputs2
 
     assert details["keyword_arguments"]["out_features"] == n_nodes
 

--- a/tests/neuralpy/layers/test_dense.py
+++ b/tests/neuralpy/layers/test_dense.py
@@ -41,21 +41,16 @@ names = ["Test", None]
 )
 def test_dense_get_layer_method(n_nodes, n_inputs, bias, name):
 	x = Dense(n_nodes=n_nodes, n_inputs=n_inputs, bias=bias, name=name)
-	prev_dim = 6
+	prev_dim = (6,)
 
 	if n_inputs is None:
-		x.get_input_dim(prev_dim)
+		x.get_input_dim(prev_dim, "dense")
 		
 	details = x.get_layer()
 
 	assert isinstance(details, dict) == True
 
-	if n_inputs:
-		assert details["n_inputs"] == n_inputs
-	else:
-		assert details["n_inputs"] == prev_dim
-
-	assert details["n_nodes"] == n_nodes
+	assert details["layer_details"] == (n_nodes,)
 
 	assert details["name"] == name
 
@@ -66,7 +61,7 @@ def test_dense_get_layer_method(n_nodes, n_inputs, bias, name):
 	if n_inputs:
 		assert details["keyword_arguments"]["in_features"] == n_inputs
 	else:
-		assert details["keyword_arguments"]["in_features"] == prev_dim
+		assert details["keyword_arguments"]["in_features"] == prev_dim[0]
 
 	assert details["keyword_arguments"]["out_features"] == n_nodes
 

--- a/tests/neuralpy/regulariziers/test_dropout.py
+++ b/tests/neuralpy/regulariziers/test_dropout.py
@@ -25,15 +25,13 @@ def test_dense_should_throw_value_error(p, name):
 def test_dense_get_layer_method(p, name):
 	x = Dropout(p=p, name=name)
 
-	assert x.get_input_dim(12) == None
+	assert x.get_input_dim(12, "dense") == None
 		
 	details = x.get_layer()
 
 	assert isinstance(details, dict) == True
 
-	assert details["n_inputs"] == None
-
-	assert details["n_nodes"] == None
+	assert details["layer_details"] == None
 
 	assert details["name"] == name
 
@@ -48,15 +46,13 @@ def test_dense_get_layer_method(p, name):
 def test_dense_get_layer_method_wit_no_parameter():
 	x = Dropout()
 
-	assert x.get_input_dim(12) == None
+	assert x.get_input_dim(12, "dense") == None
 		
 	details = x.get_layer()
 
 	assert isinstance(details, dict) == True
 
-	assert details["n_inputs"] == None
-
-	assert details["n_nodes"] == None
+	assert details["layer_details"] == None
 
 	assert details["name"] == None
 

--- a/tests/neuralpy/regulariziers/test_dropout2d.py
+++ b/tests/neuralpy/regulariziers/test_dropout2d.py
@@ -25,15 +25,13 @@ def test_dense_should_throw_value_error(p, name):
 def test_dense_get_layer_method(p, name):
 	x = Dropout2D(p=p, name=name)
 
-	assert x.get_input_dim(12) == None
+	assert x.get_input_dim(12, "dense") == None
 		
 	details = x.get_layer()
 
 	assert isinstance(details, dict) == True
 
-	assert details["n_inputs"] == None
-
-	assert details["n_nodes"] == None
+	assert details["layer_details"] == None
 
 	assert details["name"] == name
 
@@ -48,15 +46,13 @@ def test_dense_get_layer_method(p, name):
 def test_dense_get_layer_method_wit_no_parameter():
 	x = Dropout2D()
 
-	assert x.get_input_dim(12) == None
+	assert x.get_input_dim(12, "dense") == None
 		
 	details = x.get_layer()
 
 	assert isinstance(details, dict) == True
 
-	assert details["n_inputs"] == None
-
-	assert details["n_nodes"] == None
+	assert details["layer_details"] == None
 
 	assert details["name"] == None
 

--- a/tests/neuralpy/regulariziers/test_dropout3d.py
+++ b/tests/neuralpy/regulariziers/test_dropout3d.py
@@ -25,15 +25,13 @@ def test_dense_should_throw_value_error(p, name):
 def test_dense_get_layer_method(p, name):
 	x = Dropout3D(p=p, name=name)
 
-	assert x.get_input_dim(12) == None
+	assert x.get_input_dim(12, "dense") == None
 		
 	details = x.get_layer()
 
 	assert isinstance(details, dict) == True
 
-	assert details["n_inputs"] == None
-
-	assert details["n_nodes"] == None
+	assert details["layer_details"] == None
 
 	assert details["name"] == name
 
@@ -48,15 +46,13 @@ def test_dense_get_layer_method(p, name):
 def test_dense_get_layer_method_wit_no_parameter():
 	x = Dropout3D()
 
-	assert x.get_input_dim(12) == None
+	assert x.get_input_dim(12, "dense") == None
 		
 	details = x.get_layer()
 
 	assert isinstance(details, dict) == True
 
-	assert details["n_inputs"] == None
-
-	assert details["n_nodes"] == None
+	assert details["layer_details"] == None
 
 	assert details["name"] == None
 


### PR DESCRIPTION
Earlier for calculating the input shape of the next layer, we used to just pass the output shape of the previous layer.

Now, as we're working on more complicated layers, we can just pass the output shape of the previous layer, and calculate the input shape of the next layer.

In this PR,  I've changed completely how layer shapes are calculated. Now we need to pass the layer type and a tuple with all the necessary information of the previous layer, and based on that we need to calculate the input shape.

This is needed to support Conv Layers, as the calculate is complicated, and requires a lot of information of the previous layer.